### PR TITLE
Parser bug fix. Default type for Strong is unknown.

### DIFF
--- a/src/map/jsonifier.ts
+++ b/src/map/jsonifier.ts
@@ -54,7 +54,7 @@ export class MapJsonifier {
 				result[keyName] = null;
 			} else if (child instanceof StrongMap) {
 				result[keyName] = this.jsonifyMap(child);
-			} else if ((child as Strong<unknown>).typeId === 'StrongType') {
+			} else if ((child as Strong).typeId === 'StrongType') {
 				result[keyName] = this.jsonifyKey(child);
 			} else if (typeof child !== 'object') {
 				result[keyName] = this.jsonifyKey(child);
@@ -77,7 +77,7 @@ export class MapJsonifier {
 			return null;
 		}
 
-		const assumeKeyIsStrongType = key as Strong<unknown>;
+		const assumeKeyIsStrongType = key as Strong;
 
 		if (assumeKeyIsStrongType?.typeId === 'StrongType') {
 			return assumeKeyIsStrongType();

--- a/src/map/parser.ts
+++ b/src/map/parser.ts
@@ -48,7 +48,7 @@ export class MapParser {
 		return this.parseMap(map, data, parseState);
 	}
 
-	public parseStrongKey(key: Strong<unknown>, value: unknown, _parseState: State): void {
+	public parseStrongKey(key: Strong, value: unknown, _parseState: State): void {
 		if (!key || !value) {
 			return;
 		}
@@ -57,7 +57,7 @@ export class MapParser {
 			return;
 		}
 
-		const strongValue = value as Strong<unknown>;
+		const strongValue = value as Strong;
 		// When value is also a StrongType invoke it to get its value. Otherwise set
 		// the strong key with value.
 		if (strongValue.typeId === 'StrongType') {
@@ -85,8 +85,8 @@ export class MapParser {
 			return true;
 		}
 
-		let result: Strong<unknown> | unknown;
-		const strongValue = value as Strong<unknown>;
+		let result: Strong | unknown;
+		const strongValue = value as Strong;
 		if (strongValue.hasOwnProperty('typeId') && strongValue.typeId === 'StrongType') {
 			result = strongValue();
 		} else {
@@ -133,9 +133,9 @@ export class MapParser {
 			// Child is also a StrongMap. Parse it recursively.
 			if (child instanceof StrongMap) {
 				this.parseMap(child, data, parseState);
-			} else if ((child as Strong<unknown>).typeId === 'StrongType') {
+			} else if ((child as Strong)?.typeId === 'StrongType') {
 				// Child is a StrongType.
-				this.parseStrongKey(child as Strong<unknown>, keyValue, parseState);
+				this.parseStrongKey(child as Strong, keyValue, parseState);
 			} else if (typeof child !== 'object') {
 				// Child is not a StrongType and not an object.
 				this.parseKey(map, keyName, keyValue, parseState);

--- a/src/map/parser.ts
+++ b/src/map/parser.ts
@@ -132,7 +132,7 @@ export class MapParser {
 
 			// Child is also a StrongMap. Parse it recursively.
 			if (child instanceof StrongMap) {
-				this.parseMap(child, data, parseState);
+				this.parseMap(child, keyValue as Data, parseState);
 			} else if ((child as Strong)?.typeId === 'StrongType') {
 				// Child is a StrongType.
 				this.parseStrongKey(child as Strong, keyValue, parseState);

--- a/src/strong.ts
+++ b/src/strong.ts
@@ -29,7 +29,7 @@ import {StrongData} from './strong/data';
 /**
  * @category Core
  */
-export interface Strong<ValueT> {
+export interface Strong<ValueT = unknown> {
 	(val?: ValueT | null): ValueT;
 	get: (fallback: ValueT) => ValueT;
 	getNull: () => ValueT | null;


### PR DESCRIPTION
In the `strong-types` repo file `src/map/parser.ts` on line 136,
the one checking if `child.typeId === 'StrongType'`,
there should be null check.

The optional chain operator `child?.typeId` will make sure
`child` is not `undefined` or `null`.

We shouldn't do a null check before this point
because `null` is a valid value for `parseKey` to handle.