### PR TITLE
Import `@toreda/types` as type only.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@toreda/strong-types",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "Better TypeScript code in fewer lines.",
 	"main": "./dist/index",
 	"typings": "./dist/index.d.ts",

--- a/src/map.ts
+++ b/src/map.ts
@@ -23,7 +23,8 @@
  *
  */
 
-import {Data} from '@toreda/types';
+import type {Data} from '@toreda/types';
+
 import {MapJsonifier} from './map/jsonifier';
 import {MapParser} from './map/parser';
 import {StrongTypeId} from './strong/type/id';

--- a/src/map/parser.ts
+++ b/src/map/parser.ts
@@ -1,4 +1,3 @@
-import {Data} from '@toreda/types';
 /**
  *	MIT License
  *
@@ -23,10 +22,12 @@ import {Data} from '@toreda/types';
  * 	SOFTWARE.
  *
  */
+import type {Data} from '@toreda/types';
+
+import {StrongMap} from '../map';
+import {Strong} from '../strong';
 import {MapParserOptions as Options} from './parser/options';
 import {MapParserState as State} from './parser/state';
-import {Strong} from '../strong';
-import {StrongMap} from '../map';
 
 /**
  * Recursively parse provided object properties.

--- a/src/primitive/to/strong.ts
+++ b/src/primitive/to/strong.ts
@@ -23,7 +23,8 @@
  *
  */
 
-import {LiteralToPrimitive} from '@toreda/types';
+import type {LiteralToPrimitive} from '@toreda/types';
+
 import {Strong} from '../../strong';
 
 /**

--- a/src/record/to/strong/required.ts
+++ b/src/record/to/strong/required.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import {ANY, AnyObj, Expand, Primitive} from '@toreda/types';
+import type {ANY, AnyObj, Expand, Primitive} from '@toreda/types';
 
 import {PrimitiveToStrong} from '../../../primitive/to/strong';
 import {RecordToStrong} from '../strong';

--- a/src/strong/data.ts
+++ b/src/strong/data.ts
@@ -24,6 +24,7 @@
  */
 
 import type {ANY} from '@toreda/types';
+
 import {Rules} from '../rules';
 import {StrongTypeId} from './type/id';
 import {Transforms} from '../transforms';

--- a/src/type/match.ts
+++ b/src/type/match.ts
@@ -1,4 +1,4 @@
-import {ANY, Guarded, PrimitiveOrConstructor} from '@toreda/types';
+import type {ANY, Guarded, PrimitiveOrConstructor} from '@toreda/types';
 
 /**
  * Determine whether object is an instance of provided type or className.


### PR DESCRIPTION
Change `import` to `import type` for `@toreda/types` to allow the
package to be used without `@toreda/types` needed as a 'dependency'
of either package, only as a devDependency of `@toreda/strong-types`.